### PR TITLE
Update .env to hit the host instead

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-WEBHOOK_URL=http://localhost:3010/webhooks
+WEBHOOK_URL=http://host.docker.internal:3010/webhooks
 WEBHOOK_SECRET=mySecret


### PR DESCRIPTION
The config in the env file sends the webhook request inside the docker container the server is running. This PR aims to modify  that so that it hits the localhost of the host machine where the webhook request accepting localserver is running.